### PR TITLE
Test plugin with GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      
+      - run: brew install robotsandpencils/made/xcodes 
 
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: asdf_plugin_test
+        uses: asdf-vm/actions/plugin-test@v1
+        with:
+          version: "12.4"
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1
         with:
+          command: xcodebuild -version
           version: "12.4"
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+xcodes install --directory "$ASDF_DOWNLOAD_PATH" "$ASDF_INSTALL_VERSION"


### PR DESCRIPTION
Use the GitHub action provided by asdf to test asdf-xcode. 

For more information see:
https://github.com/asdf-vm/actions